### PR TITLE
update to rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ARG BNFC_COMMIT=ce7fe1fd08d9d808c14ff626c321218c5b73e38b
 RUN git clone https://github.com/BNFC/bnfc . && git checkout $BNFC_COMMIT
 RUN stack init && stack setup
 RUN stack build && stack install --local-bin-path=.
-
 # Container for building RChain
 # bionic = 18.04
 FROM ubuntu:bionic
@@ -19,16 +18,18 @@ RUN apt update \
         gnupg \
         locales \
         lsb-release \
+        software-properties-common \
     && sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     && locale-gen \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 \
     && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-    && echo 'deb https://dl.bintray.com/sbt/debian /' >/etc/apt/sources.list.d/sbt.list \
+    && echo 'deb https://repo.scala-sbt.org/scalasbt/debian all main' > /etc/apt/sources.list.d/sbt.list \
     && echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" >/etc/apt/sources.list.d/docker-ce.list \
     && echo 'deb https://packages.cloud.google.com/apt cloud-sdk main' >/etc/apt/sources.list.d/google-cloud-sdk.list \
     && echo "deb https://packages.cloud.google.com/apt gcsfuse-$(lsb_release -cs) main" >/etc/apt/sources.list.d/gcsfuse.list
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 PYENV_ROOT=/opt/pyenv
+RUN apt-add-repository ppa:git-core/ppa
 RUN apt update \
     && apt install -y --no-install-recommends \
         build-essential \


### PR DESCRIPTION
The pr is intended to rebuild the image with higher git version.

**The image is used also in [rchain main repo](https://github.com/rchain/rchain/blob/dev/.github/workflows/continuous-integration.yml#L40)**.

Higher git version is required in https://github.com/rchain/rchain-ci

Currently the problem is the with git version lower than  `2.18`. `Checkout acions` in github actions would only download the raw data repo . Showed below(last line)
![image](https://user-images.githubusercontent.com/13496262/134675357-21168f83-4819-491b-9d10-81ca6fc6bd47.png)

In order to commit easily by the robot user, we need to upgrade git version.

The first commit https://github.com/rchain/buildenv/pull/6/commits/e32ab9f523ef0e7f750fd03bca5cb653fde8ab56 is aimed to do that.

The second commit https://github.com/rchain/buildenv/pull/6/commits/3835eace08347c0022eaa2148a4ca0edd4038d5b is to replace `bnfc` with easy cabal-install. (The second one can be omitted if we don't want to change that.)
